### PR TITLE
Add THcNPSCoinTime, other cluster class updates

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(src
   THcNPSShowerHit.cxx
   THcNPSCluster.cxx
   THcNPSSecondaryKine.cxx
+  THcNPSCoinTime.cxx
   VTPModule.cxx
   )
 

--- a/src/NPS_LinkDef.h
+++ b/src/NPS_LinkDef.h
@@ -11,6 +11,7 @@
 #pragma link C++ class THcNPSShowerHit+;
 #pragma link C++ class THcNPSCluster+;
 #pragma link C++ class THcNPSSecondaryKine+;
+#pragma link C++ class THcNPSCoinTime+;
 #pragma link C++ class Decoder::VTPModule+;
 
 #endif

--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -762,6 +762,7 @@ Int_t THcNPSArray::CoarseProcess(TClonesArray& tracks)
 	   << "  X=" << clX(*ppcl)
 	   << "  Y=" << clY(*ppcl)
 	   << "  Z=" << clZ(*ppcl)
+	   << "  T=" << clT(*ppcl)
 	   << "  size=" << (**ppcl).size()
 	   << endl;
 

--- a/src/THcNPSCalorimeter.cxx
+++ b/src/THcNPSCalorimeter.cxx
@@ -385,11 +385,11 @@ Int_t THcNPSCalorimeter::DefineVariables( EMode mode )
     { "nhits",        "Number of hits",                             "fNhits" },
     { "nclust",       "Number of layer clusters",                   "fNclust" },
     { "etot",         "Total energy",                               "fEtot" },
-    { "etrack",       "Track energy",                               "fEtrack" },  // We don't really need these track associated variables, remove?
-    { "eprtrack",     "Track Preshower energy",                     "fEPRtrack" },
-    { "eprtracknorm", "Preshower energy divided by track momentum", "fEPRtrackNorm" },
-    { "etottracknorm","Total energy divided by track momentum",     "fETotTrackNorm" },
-    //{ "ntracks", "Number of shower tracks",                      "fNtracks" }, //C.Y. Jan 13, 2021, comment out to prevent replay errors for now.
+    { "clusX",        "Cluster x coordinate",                       "fClusterX" },
+    { "clusY",        "Cluster y coordinate",                       "fClusterY" },
+    { "clusZ",        "Cluster z coordinate",                       "fClusterZ" },
+    { "clusT",        "Cluster time",                               "fClusterT" },
+    { "clusE",        "Cluster energy",                             "fClusterE" },
     { "vtpErrorFlag", "VTP error flag",           "fVTPErrorFlag"     },
     { "vtpTrigTime",  "VTP trigger time",         "fVTPTriggerTime"   },
     { "vtpTrigType0", "VTP trigger type0 bit",    "fVTPTriggerType0"  },
@@ -493,6 +493,14 @@ void THcNPSCalorimeter::Clear(Option_t* opt)
     delete *i;
   }
   fClusterList->clear();
+
+  fClusters.clear();
+
+  fClusterX.clear();
+  fClusterY.clear();
+  fClusterZ.clear();
+  fClusterT.clear();
+  fClusterE.clear();
 }
 
 //_____________________________________________________________________________
@@ -698,6 +706,22 @@ void THcNPSCalorimeter::ClusterHits(THcNPSShowerHitSet& HitSet,
 
   } //While hit_list not exhausted
 
+
+  fNclust = (*ClusterList).size();
+
+  // Add clusters
+  for (THcNPSShowerClusterListIt ppcl = (*ClusterList).begin(); 
+       ppcl != (*ClusterList).end(); ++ppcl) {
+    THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
+    fClusters.push_back(cls);
+
+    fClusterX.push_back(cls.X());
+    fClusterY.push_back(cls.Y());
+    fClusterZ.push_back(cls.Z());
+    fClusterT.push_back(cls.T());
+    fClusterE.push_back(cls.E());
+  }
+
   // C.Y. Apr 07, 2021: Added lines to write clusters to file for plotting in 2D grid (and comparing to NPS clustering approach)
   if(fMakeGrid) {
 
@@ -717,7 +741,6 @@ void THcNPSCalorimeter::ClusterHits(THcNPSShowerHitSet& HitSet,
     } //end loop over clusters
 
   } //end fMakeGrid requirement
-  
    
 };
 
@@ -1096,6 +1119,19 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
     
   }
 
+  fNclust = (*ClusterList).size();
+
+  for (THcNPSShowerClusterListIt ppcl = (*ClusterList).begin(); 
+       ppcl != (*ClusterList).end(); ++ppcl) {
+    THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
+    fClusters.push_back(cls);
+
+    fClusterX.push_back(cls.X());
+    fClusterY.push_back(cls.Y());
+    fClusterZ.push_back(cls.Z());
+    fClusterT.push_back(cls.T());
+    fClusterE.push_back(cls.E());
+  }
   
   // C.Y. Apr 07, 2021: Added lines to write clusters to file for plotting in 2D grid (and comparing to NPS clustering approach)
   if(fMakeGrid) {
@@ -1252,16 +1288,6 @@ Int_t THcNPSCalorimeter::FineProcess( TClonesArray& tracks )
 {
 
   //cout << "Calling THcNPSCalorimeter::FineProcess() . . . " << endl;
-
-  fClusters.clear();
-
-  // Loop over all clusters, get position, time, and energy
-  for(THcNPSShowerClusterListIt ppcl = (*fClusterList).begin();
-      ppcl != (*fClusterList).end(); ++ppcl) {
-    THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
-    fClusters.push_back(cls);
-  }
-  
   return 0;
 }
 

--- a/src/THcNPSCalorimeter.cxx
+++ b/src/THcNPSCalorimeter.cxx
@@ -1150,11 +1150,13 @@ Double_t addZ(Double_t x, THcNPSShowerHit* h) {
   return x + h->hitE() * h->hitZ();
 }
 
+Double_t addT(Double_t x, THcNPSShowerHit* h) {
+  return x + h->hitE() * h->hitT();
+}
+
 Double_t addEpr(Double_t x, THcNPSShowerHit* h) {
   return h->hitColumn() == 0 ? x + h->hitE() : x;
 }
-
-
 
 // Y coordinate of center of gravity of cluster, calculated as hit energy
 // weighted average. Put X out of the calorimeter (-100 cm), if there is no
@@ -1183,6 +1185,15 @@ Double_t clZ(THcNPSShowerCluster* cluster) {
   Double_t Etot = accumulate((*cluster).begin(),(*cluster).end(),0.,addE);
   return (Etot != 0. ?
 	  accumulate((*cluster).begin(),(*cluster).end(),0.,addZ)/Etot : 0.);
+}
+
+// Time of cluster, calculated as a hit energy weighted average.
+// Put T at -1000 ns if there is no energy deposition in cluster.
+//
+Double_t clT(THcNPSShowerCluster* cluster) {
+  Double_t Etot = accumulate((*cluster).begin(),(*cluster).end(),0.,addE);
+  return (Etot != 0. ?
+	  accumulate((*cluster).begin(),(*cluster).end(),0.,addT)/Etot : 0.);
 }
 
 //Energy depostion in a cluster
@@ -1244,10 +1255,10 @@ Int_t THcNPSCalorimeter::FineProcess( TClonesArray& tracks )
 
   fClusters.clear();
 
-  // Loop over all clusters, get position and energy
+  // Loop over all clusters, get position, time, and energy
   for(THcNPSShowerClusterListIt ppcl = (*fClusterList).begin();
       ppcl != (*fClusterList).end(); ++ppcl) {
-    THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clE(*ppcl));
+    THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
     fClusters.push_back(cls);
   }
   

--- a/src/THcNPSCalorimeter.h
+++ b/src/THcNPSCalorimeter.h
@@ -230,6 +230,7 @@ Double_t addE(Double_t x, THcNPSShowerHit* h);
 Double_t addX(Double_t x, THcNPSShowerHit* h);
 Double_t addY(Double_t x, THcNPSShowerHit* h);
 Double_t addZ(Double_t x, THcNPSShowerHit* h);
+Double_t addT(Double_t x, THcNPSShowerHit* h);
 Double_t addEpr(Double_t x, THcNPSShowerHit* h);
 
 // Methods to calculate coordinates and energy depositions for a given cluster.
@@ -237,6 +238,7 @@ Double_t addEpr(Double_t x, THcNPSShowerHit* h);
 Double_t clX(THcNPSShowerCluster* cluster);
 Double_t clY(THcNPSShowerCluster* cluster);
 Double_t clZ(THcNPSShowerCluster* cluster);
+Double_t clT(THcNPSShowerCluster* cluster);
 Double_t clE(THcNPSShowerCluster* cluster);
 Double_t clEpr(THcNPSShowerCluster* cluster);
 //Double_t clEplane(THcNPSShowerCluster* cluster, Int_t iplane, Int_t side);

--- a/src/THcNPSCalorimeter.h
+++ b/src/THcNPSCalorimeter.h
@@ -101,6 +101,14 @@ protected:
   // Cluster array 
   std::vector<THcNPSCluster> fClusters;
 
+  // M. Mathison Sep. 11, 2023: Added cluster variables for root output
+
+  std::vector<Double_t> fClusterX;
+  std::vector<Double_t> fClusterY;
+  std::vector<Double_t> fClusterZ;
+  std::vector<Double_t> fClusterT;
+  std::vector<Double_t> fClusterE;
+
   // DJH: VTP stuff
   static const Int_t fnVTP = 5;
   Int_t fVTPErrorFlag;
@@ -163,7 +171,6 @@ protected:
   THcNPSAnalyzer *fAnalyzer;
 
   Int_t fClustMethod;
-
   
   // Geometrical parameters.
 

--- a/src/THcNPSCluster.cxx
+++ b/src/THcNPSCluster.cxx
@@ -3,24 +3,65 @@
 
 //______________________________________________________
 THcNPSCluster::THcNPSCluster() :
-  fE(0)
+  fE(0),
+  fT(0),
+  fHasVertex(false),
 {
   // Constructor
+
+  // Initialize momentum and vertex vectors
+  fPvect.SetXYZ(0., 0., 0.);
+  fVertex.SetXYZ(0., 0., 0.);
+  fCenterLab.SetXYZ(0., 0., 0.,);
 }
 
 //______________________________________________________
-THcNPSCluster::THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t e)
+THcNPSCluster::THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t e, Double_t t)
 {  
   fCenter.SetXYZ(x, y, z);
   fE = e;
+  fT = t;
+
+  fPvect.SetXYZ(0., 0., 0.);
+  fVertex.SetXYZ(0., 0., 0.);
+  fCenterLab.SetXYZ(0., 0., 0.,);
+  fHasVertex = false;
 }
 
 //______________________________________________________
 void THcNPSCluster::Clear( Option_t* )
-
 {
   fCenter.SetXYZ( kBig, kBig, kBig);
+  fPvect.SetXYZ( kBig, kBig, kBig);
+  fVertex.SetXYZ( kBig, kBig, kBig);
+  fCenterLab.SetXYZ( kBig, kBig, kBig);
+  fHasVertex = false;
   fE = 0;
+  fT = 0;
+}
+
+//______________________________________________________
+virtual void THcNPSCluster::RotateToLab(Double_t angle, TVector3& vertex, TVector3& pvect)
+{
+  // Set vertex vector
+  fVertex = vertex;
+  fHasVertex = true;
+
+  // Rotate along y-axis, correct for vertex
+  Double_t x_lab = fCenter.X()*cos(angle)  + fCenter.Z()*sin(angle) - vertex.X();
+  Double_t y_lab = fCenter.Y() - vertex.Y();
+  Double_t z_lab = -fCenter.X()*sin(angle) + fCenter.Z()*cos(angle) - vertx.Z();
+
+  TVector3 rvect(x_lab, y_lab, z_lab);
+  Double_t th = rvect.Theta();
+  Double_t ph = rvect.Phi();
+  
+  fCenterLab = rvect;
+  fPvect.SetXYZ(fE * cos(th) * sin(ph),
+	    fE * sin(th) * sin(ph),
+	    fE * cos(ph));
+
+  pvect = fPvect;
 }
 
 //______________________________________________________

--- a/src/THcNPSCluster.cxx
+++ b/src/THcNPSCluster.cxx
@@ -33,7 +33,7 @@ THcNPSCluster::THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t t, Dou
 //______________________________________________________
 void THcNPSCluster::Clear( Option_t* )
 {
-  fCenter.SetXYZ( kBig, kBig, kBig);
+  fCenter.SetXYZ(kBig, kBig, kBig);
   fPvect.SetXYZ( kBig, kBig, kBig);
   fVertex.SetXYZ( kBig, kBig, kBig);
   fCenterLab.SetXYZ( kBig, kBig, kBig);

--- a/src/THcNPSCluster.cxx
+++ b/src/THcNPSCluster.cxx
@@ -3,28 +3,30 @@
 
 //______________________________________________________
 THcNPSCluster::THcNPSCluster() :
-  fE(0),
-  fT(0),
-  fHasVertex(false),
+  fE(kBig),
+  fT(kBig),
+  fP(kBig),
+  fHasVertex(false)
 {
   // Constructor
 
   // Initialize momentum and vertex vectors
   fPvect.SetXYZ(0., 0., 0.);
   fVertex.SetXYZ(0., 0., 0.);
-  fCenterLab.SetXYZ(0., 0., 0.,);
+  fCenterLab.SetXYZ(0., 0., 0.);
 }
 
 //______________________________________________________
-THcNPSCluster::THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t e, Double_t t)
+THcNPSCluster::THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t t, Double_t e)
 {  
   fCenter.SetXYZ(x, y, z);
   fE = e;
   fT = t;
+  fP = e; // assume photon
 
   fPvect.SetXYZ(0., 0., 0.);
   fVertex.SetXYZ(0., 0., 0.);
-  fCenterLab.SetXYZ(0., 0., 0.,);
+  fCenterLab.SetXYZ(0., 0., 0.);
   fHasVertex = false;
 }
 
@@ -36,12 +38,11 @@ void THcNPSCluster::Clear( Option_t* )
   fVertex.SetXYZ( kBig, kBig, kBig);
   fCenterLab.SetXYZ( kBig, kBig, kBig);
   fHasVertex = false;
-  fE = 0;
-  fT = 0;
+  fE = fT = fP = kBig;
 }
 
 //______________________________________________________
-virtual void THcNPSCluster::RotateToLab(Double_t angle, TVector3& vertex, TVector3& pvect)
+void THcNPSCluster::RotateToLab(Double_t angle, TVector3& vertex, TVector3& pvect)
 {
   // Set vertex vector
   fVertex = vertex;
@@ -50,18 +51,18 @@ virtual void THcNPSCluster::RotateToLab(Double_t angle, TVector3& vertex, TVecto
   // Rotate along y-axis, correct for vertex
   Double_t x_lab = fCenter.X()*cos(angle)  + fCenter.Z()*sin(angle) - vertex.X();
   Double_t y_lab = fCenter.Y() - vertex.Y();
-  Double_t z_lab = -fCenter.X()*sin(angle) + fCenter.Z()*cos(angle) - vertx.Z();
+  Double_t z_lab = -fCenter.X()*sin(angle) + fCenter.Z()*cos(angle) - vertex.Z();
 
   TVector3 rvect(x_lab, y_lab, z_lab);
   Double_t th = rvect.Theta();
   Double_t ph = rvect.Phi();
   
   fCenterLab = rvect;
-  fPvect.SetXYZ(fE * cos(th) * sin(ph),
-	    fE * sin(th) * sin(ph),
-	    fE * cos(ph));
-
-  pvect = fPvect;
+  pvect.SetXYZ(fE * cos(th) * sin(ph),
+	       fE * sin(th) * sin(ph),
+	       fE * cos(ph));
+  
+  fPvect = pvect;
 }
 
 //______________________________________________________
@@ -69,7 +70,7 @@ void THcNPSCluster::Print( Option_t* ) const
 {
   // Print contents of cluster, XYZ and E
 
-  std::cout << fCenter.X() << " " << fCenter.Y() << " " << fCenter.Z() << " " << fE << std::endl;
+  std::cout << fCenter.X() << " " << fCenter.Y() << " " << fCenter.Z() << " " << fT << " " << fE << std::endl;
 
 }
 

--- a/src/THcNPSCluster.h
+++ b/src/THcNPSCluster.h
@@ -24,7 +24,8 @@ class THcNPSCluster : public THaCluster {
   // Getter/Setter functions
   bool       HasVertex()          const { return fHasVertex; }
   Double_t   E()                  const { return fE; }
-  Double_t   GetTime()                  { return fT; }
+  Double_t   T()                  const { return fT; }
+  Double_t   GetTime()            const { return fT; }
   TVector3&  GetPvect()                 { return fPvect; } 
   TVector3&  GetVertex()                { return fVertex; }
   Double_t   GetTheta()                 { return fPvect.Theta(); } // in lab frame

--- a/src/THcNPSCluster.h
+++ b/src/THcNPSCluster.h
@@ -13,7 +13,7 @@
 class THcNPSCluster : public THaCluster {
  public:
   THcNPSCluster();
-  THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t e, Double_t t);
+  THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t t, Double_t e);
   virtual ~THcNPSCluster() = default;
 
   virtual void Clear( Option_t* opt="" );
@@ -25,20 +25,26 @@ class THcNPSCluster : public THaCluster {
   // Getter/Setter functions
   bool       HasVertex()          const { return fHasVertex; }
   Double_t   E()                  const { return fE; }
-  void       GetTime()                  { return fT; }
+  Double_t   GetTime()                  { return fT; }
   TVector3&  GetPvect()                 { return fPvect; } 
   TVector3&  GetVertex()                { return fVertex; }
-  void       GetTheta()                 { return fPvect.Theta(); } // in lab frame
-  void       GetPhi()                   { return fPvect.Phi(); }   // in lab frame
+  Double_t   GetTheta()                 { return fPvect.Theta(); } // in lab frame
+  Double_t   GetPhi()                   { return fPvect.Phi(); }   // in lab frame
+  Double_t   GetP()               const { return fP; }
 
-  void       SetEnergy(Double_t energy) { fE = energy; }
-  void       SetTime(Double_t time)     { fT = time; }
-  void       SetVertex(const TVector3& vertex) { fVertex = vertex; fHasVertex = true; }
-  void       SetVertex(Double_t vx, Double_t vy, Double_t vz) { fVertex.SetXYZ(vx, vy, vz); fHasVertex = true; }
+  void       SetEnergy(Double_t energy)      { fE = energy; }
+  void       SetTime(Double_t time)          { fT = time; }
+  void       SetMomentum( Double_t p )       { fP = p; }
   void       SetPvect(const TVector3& pvect) { fPvect = pvect; }
+
+  void       SetVertex(const TVector3& vertex) 
+  { fVertex = vertex; fHasVertex = true; }
+  void       SetVertex(Double_t vx, Double_t vy, Double_t vz) 
+  { fVertex.SetXYZ(vx, vy, vz); fHasVertex = true; }
 
  protected:
 
+  Double_t fP;          // momentum
   Double_t fE;          // Cluster energy deposit
   Double_t fT;          // Cluster time
   bool     fHasVertex;   

--- a/src/THcNPSCluster.h
+++ b/src/THcNPSCluster.h
@@ -8,23 +8,44 @@
 //////////////////////////////////////
 
 #include "THaCluster.h"
+#include "TVector3.h"
 
 class THcNPSCluster : public THaCluster {
  public:
   THcNPSCluster();
-  THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t e);
+  THcNPSCluster(Double_t x, Double_t y, Double_t z, Double_t e, Double_t t);
   virtual ~THcNPSCluster() = default;
 
   virtual void Clear( Option_t* opt="" );
   virtual void Print( Option_t* opt="" ) const;
 
-  Double_t E() const { return fE; }
-  void     SetEnergy(Double_t e) { fE = e; }
+  // Coordinate transformation from detector plane to lab
+  virtual void RotateToLab(Double_t angle, TVector3& vertex, TVector3& pvect);
+
+  // Getter/Setter functions
+  bool       HasVertex()          const { return fHasVertex; }
+  Double_t   E()                  const { return fE; }
+  void       GetTime()                  { return fT; }
+  TVector3&  GetPvect()                 { return fPvect; } 
+  TVector3&  GetVertex()                { return fVertex; }
+  void       GetTheta()                 { return fPvect.Theta(); } // in lab frame
+  void       GetPhi()                   { return fPvect.Phi(); }   // in lab frame
+
+  void       SetEnergy(Double_t energy) { fE = energy; }
+  void       SetTime(Double_t time)     { fT = time; }
+  void       SetVertex(const TVector3& vertex) { fVertex = vertex; fHasVertex = true; }
+  void       SetVertex(Double_t vx, Double_t vy, Double_t vz) { fVertex.SetXYZ(vx, vy, vz); fHasVertex = true; }
+  void       SetPvect(const TVector3& pvect) { fPvect = pvect; }
 
  protected:
 
-  Double_t fE; // Cluster energy deposit
-  
+  Double_t fE;          // Cluster energy deposit
+  Double_t fT;          // Cluster time
+  bool     fHasVertex;   
+  TVector3 fVertex;     // vertex information from other spectrometer
+  TVector3 fPvect;      // momentum vector
+  TVector3 fCenterLab;  
+
   ClassDef(THcNPSCluster,0)
 
 };

--- a/src/THcNPSCluster.h
+++ b/src/THcNPSCluster.h
@@ -8,7 +8,6 @@
 //////////////////////////////////////
 
 #include "THaCluster.h"
-#include "TVector3.h"
 
 class THcNPSCluster : public THaCluster {
  public:
@@ -44,9 +43,9 @@ class THcNPSCluster : public THaCluster {
 
  protected:
 
-  Double_t fP;          // momentum
   Double_t fE;          // Cluster energy deposit
   Double_t fT;          // Cluster time
+  Double_t fP;          // momentum
   bool     fHasVertex;   
   TVector3 fVertex;     // vertex information from other spectrometer
   TVector3 fPvect;      // momentum vector

--- a/src/THcNPSCoinTime.cxx
+++ b/src/THcNPSCoinTime.cxx
@@ -1,6 +1,8 @@
 #include "THcNPSCoinTime.h"
+#include "THcGlobals.h"
+#include "THcParmList.h"
+#include "THaEvData.h"
 #include "THcNPSCluster.h"
-
 #include <iostream>
 
 using namespace std;
@@ -12,7 +14,7 @@ THcNPSCoinTime::THcNPSCoinTime( const char* name, const char* description,
   THaPhysicsModule(name, description),
   fCoinDetName(coinname),
   fCoinDet(nullptr),
-  felecArmName(eleArmName),
+  felecArmName(elecArmName),
   fhadArmName(hadArmName),
   fHMSSpect(nullptr),
   fNPSSpect(nullptr)
@@ -28,22 +30,22 @@ THcNPSCoinTime::~THcNPSCoinTime()
 }
 
 //________________________________________________________________________
-THcNPSCoinTime::Clear( Option_t* opt )
+void THcNPSCoinTime::Clear( Option_t* opt )
 {
 
-  fROC1_epCoinTime = kBig;
-  fROC_RAW_CoinTime = fNPS_RAW_CoinTime = fHMS_RAW_CoinTime = kBig;
-  elec_coinCorr = had_coinCorr_Proton = kBig;
+  fROC1_epCoinTime1 = fROC1_epCoinTime2 =  kBig;
+  fROC1_RAW_CoinTime1 = fROC1_RAW_CoinTime2 = fNPS_RAW_CoinTime = fHMS_RAW_CoinTime = kBig;
+  elec_coinCorr = had_coinCorr_proton = kBig;
 }
 
 //________________________________________________________________________
-THcNPSCoinTime::Reset( Option_t* opt )
+void THcNPSCoinTime::Reset( Option_t* opt )
 {
   Clear(opt);
 }
 
 //________________________________________________________________________
-THaAnalysisObject::Estatus THcNPSCoinTime::Init( const TDatime& run_time )
+THaAnalysisObject::EStatus THcNPSCoinTime::Init( const TDatime& run_time )
 {
 
   // Locate the spectrometer appratus and save pointer to it
@@ -56,29 +58,28 @@ THaAnalysisObject::Estatus THcNPSCoinTime::Init( const TDatime& run_time )
 
   fStatus = kOK;
 
-  if (THaPhysicsModule::Init( run_time ) != kOK )
-    return fStatus;
-
   // Get spectrometers
   if (felecArmName == "H") {
     // HMS
-    fHMSSpect = dynamic_cast<THaSpectrometer*>
+    fHMSSpect = dynamic_cast<THcHallCSpectrometer*>
       ( FindModule( felecArmName.Data(), "THcHallCSpectrometer"));
     // NPS
     fNPSSpect = dynamic_cast<THcNPSApparatus*>
       ( FindModule( fhadArmName.Data(), "THcNPSApparatus"));
   }
   else {
-    fHMSSpect = dynamic_cast<THaSpectrometer*>
+    fHMSSpect = dynamic_cast<THcHallCSpectrometer*>
       ( FindModule( fhadArmName.Data(), "THcHallCSpectrometer"));
     
-    fNPSpect = dynamic_cast<THcNPSApparatus*>
+    fNPSSpect = dynamic_cast<THcNPSApparatus*>
       ( FindModule( felecArmName.Data(), "THcNPSApparatus"));
   }
 
-  if( !fHMSSpect || !fNPSSpect )
+  if( !fHMSSpect || !fNPSSpect ) {
     fStatus = kInitError;
-  
+    return fStatus;
+  }
+
   fCoinDet = dynamic_cast<THcTrigDet*>
     ( FindModule( fCoinDetName.Data(), "THcTrigDet"));
   if( !fCoinDet ) {
@@ -90,13 +91,16 @@ THaAnalysisObject::Estatus THcNPSCoinTime::Init( const TDatime& run_time )
   // Get NPS calorimeter
   fNPSCalo = dynamic_cast<THcNPSCalorimeter*>(fNPSSpect->GetDetector("cal"));
   if( !fNPSCalo ) {
-    cout <<
     fStatus = kInitError;
+    return fStatus;
   }
 
   // NPS angle   
   fNPSAngle = TMath::DegToRad()*fNPSSpect->GetNPSAngle();
   
+  if ((fStatus=THaPhysicsModule::Init( run_time )) != kOK )
+    return fStatus;
+
   return fStatus;
 }
 
@@ -114,7 +118,7 @@ Int_t THcNPSCoinTime::ReadDatabase( const TDatime& date )
   // Default values if not read from param file
   feHad_CT_Offset = 0.0;
   fHMScentralPathLen = 22.*100;
-  fNPScentralPathLen = 18.1*100; // FIXME: update value for NPS!
+  fNPScentralPathLen = 9.5*100; 
 
   gHcParms->LoadParmValues((DBRequest*)&list, "");
 
@@ -129,18 +133,20 @@ Int_t THcNPSCoinTime::DefineVariables( EMode mode )
   fIsSetup = ( mode == kDefine );
 
   RVarDef vars[] = {
-    {"epCoinTime_ROC1",    "ROC1 Corrected ep Coincidence Time", "fROC1_epCoinTime"},
+    {"epCoinTime1_ROC1",   "ROC1 Corrected ep Coincidence Time, NPS & HMS 3/4", "fROC1_epCoinTime1"},
+    {"epCoinTime2_ROC1",   "ROC1 Corrected ep Coincidence Time, NPS & El-Real", "fROC1_epCoinTime2"},
     {"epCoinTime_NPS",     "NPS Corrected ep Coincidence Time",  "fNPS_epCoinTime"},
     {"epCoinTime_HMS",     "HMS Corrected ep Coincidence Time",  "fHMS_epCoinTime"},
     
-    {"CoinTime_RAW_ROC1",  "ROC1 RAW Coincidence Time",          "fROC1_RAW_CoinTime"},
-    {"CoinTime_RAW_NPS",   "NPS RAW Coincidence Time",           "fNPS_RAW_CoinTime"},
-    {"CoinTime_RAW_HMS",   "HMS RAW Coincidence Time",           "fHMS_RAW_CoinTime"},
+    {"CoinTime1_RAW_ROC1", "ROC1 RAW Coincidence Time, NPS & HMS 3/4",     "fROC1_RAW_CoinTime1"},
+    {"CoinTime2_RAW_ROC1", "ROC1 RAW Coincidence Time, NPS & El-Real",     "fROC1_RAW_CoinTime2"},
+    {"CoinTime_RAW_NPS",   "NPS RAW Coincidence Time",                     "fNPS_RAW_CoinTime"},
+    {"CoinTime_RAW_HMS",   "HMS RAW Coincidence Time",                     "fHMS_RAW_CoinTime"},
 
-    {"DeltaHMSPathLength", "DeltaHMSpathLength (cm)",            "fDeltaHMSpathLength"},
+    {"DeltaHMSPathLength", "DeltaHMSpathLength (cm)",  "fDeltaHMSpathLength"},
 
-    {"elec_coinCorr",          "",  "elec_coinCorr"},
-    {"had_coinCorr_proton",    "",  "had_coinCorr_Proton"},
+    {"elec_coinCorr",      "",                         "elec_coinCorr"},
+    {"had_coinCorr_proton","",                         "had_coinCorr_proton"},
     {0}
   };
 
@@ -166,7 +172,7 @@ Int_t THcNPSCoinTime::Process( const THaEvData& evdata )
 
   // Loop over all clusters
   // We don't have a "Golden cluster", use highest energy cluster for now
-  Double_t ClustMaxE = 0.;
+  Double_t ClusterMaxE = 0.;
   Double_t NPS_FPtime = kBig;
   TVector3 pvect;
   TVector3 vertex = theHMSTrack->GetVertex();  // Use vertex from HMS
@@ -184,21 +190,22 @@ Int_t THcNPSCoinTime::Process( const THaEvData& evdata )
 
   // HMS
   Double_t hms_xptar = theHMSTrack->GetTTheta();
-  Double_t hms_dP = theHMSTrack->GEtDp();
-  Double_t hms_xfp = theHMSTrack->GEtX();
+  Double_t hms_dP = theHMSTrack->GetDp();
+  Double_t hms_xfp = theHMSTrack->GetX();
   Double_t hms_xpfp = theHMSTrack->GetTheta();
   Double_t hms_ypfp = theHMSTrack->GetPhi();
   Double_t HMS_FPtime = theHMSTrack->GetFPTime();
   
-  // Assume these are values when the variable is initialized
+  // Assume these are the values when the variable is initialized
   if (NPS_FPtime == -2000 || HMS_FPtime == -2000) return 1;
   if (NPS_FPtime == -1000 || HMS_FPtime == -1000) return 1;
 
   // We only use ROC1
-  pNPS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);  // pTRIG1_ROC1
-  pHMS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  // pTRIG3_ROC1
+  pNPS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);   // pTRIG1_ROC1: NPS VTP
+  pHMS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);   // pTRIG3_ROC1: HMS 3/4
+  pELRE_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(3);  // pTRIG4_ROC1: HMS ELREAL
   
-  fDeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp);
+  fDeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*hms_xfp - 116.52*hms_ypfp*hms_ypfp);
   fDeltaHMSpathLength = (.12*hms_xptar*1000 +0.17*hms_dP/100.);
   
   // First assume NPS is the electron arm
@@ -216,33 +223,25 @@ Int_t THcNPSCoinTime::Process( const THaEvData& evdata )
   }
   
   // beta calculations beta = v/c = p/E
-  elecArm_BetaCalc = elec_P / sqrt(elec_P*elec_P + MASS_ELECTRON*MASS_ELECTRON);
-  hadArm_BetaCalc_proton = had_P / sqrt(had_P*had_P + MASS_PROTON*MASS_PROTON);
+  Double_t elecArm_BetaCalc = elec_P / sqrt(elec_P*elec_P + MASS_ELECTRON*MASS_ELECTRON);
+  Double_t hadArm_BetaCalc_proton = had_P / sqrt(had_P*had_P + MASS_PROTON*MASS_PROTON);
 
   //Coincidence Corrections
   elec_coinCorr = (ElecPathLength) / (LIGHTSPEED * elecArm_BetaCalc );
   had_coinCorr_proton = (HadPathLength) / (LIGHTSPEED * hadArm_BetaCalc_proton );
 
-  // Comment out other hadron parts, keeping here in case someone needs them.
-  /*
-  hadArm_BetaCalc_Kaon = had_P / sqrt(had_P*had_P + kaonMass*kaonMass);
-  hadArm_BetaCalc_Pion = had_P / sqrt(had_P*had_P + pionMass*pionMass);	
-  hadArm_BetaCalc_Positron = had_P / sqrt(had_P*had_P + positronMass*positronMass);
-
-  had_coinCorr_Kaon =  (HadPathLength)/ (lightSpeed * hadArm_BetaCalc_Kaon );
-  had_coinCorr_Pion =  (HadPathLength)/ (lightSpeed * hadArm_BetaCalc_Pion );
-  had_coinCorr_Positron = (HadPathLength) / (lightSpeed SHMSadArm_BetaCalc_PSHMStron );
-  */  
-
-  //Raw, Uncorrected Coincidence Time
-  fROC1_RAW_CoinTime =  (pNPS_TdcTime_ROC1 + NPS_FPtime) - (pHMS_TdcTime_ROC1 + HMS_FPtime);
+  // Raw, Uncorrected Coincidence Time
+  // Since we have two coincidence trig, check both
+  fROC1_RAW_CoinTime1 =  (pNPS_TdcTime_ROC1 + NPS_FPtime) - (pHMS_TdcTime_ROC1 + HMS_FPtime);
+  fROC1_RAW_CoinTime2 =  (pNPS_TdcTime_ROC1 + NPS_FPtime) - (pELRE_TdcTime_ROC1 + HMS_FPtime);
 
   // Not sure if we want to keep those
   fNPS_RAW_CoinTime = NPS_FPtime - HMS_FPtime; // essentially same as fHMS_RAW_CoinTime
   fHMS_RAW_CoinTime = NPS_FPtime - HMS_FPtime;
 
   // Corrected Coincidence Time for ROC1
-  fROC1_epCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; 
+  fROC1_epCoinTime1 = fROC1_RAW_CoinTime1 + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; 
+  fROC1_epCoinTime2 = fROC1_RAW_CoinTime2 + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; 
   fNPS_epCoinTime = fNPS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; // essentially same as fHMS_epCoinTime
   fHMS_epCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; 
 

--- a/src/THcNPSCoinTime.cxx
+++ b/src/THcNPSCoinTime.cxx
@@ -1,0 +1,252 @@
+#include "THcNPSCoinTime.h"
+#include "THcNPSCluster.h"
+
+#include <iostream>
+
+using namespace std;
+
+//________________________________________________________________________
+THcNPSCoinTime::THcNPSCoinTime( const char* name, const char* description,
+				const char* elecArmName, const char* hadArmName,
+				const char* coinname) :
+  THaPhysicsModule(name, description),
+  fCoinDetName(coinname),
+  fCoinDet(nullptr),
+  felecArmName(eleArmName),
+  fhadArmName(hadArmName),
+  fHMSSpect(nullptr),
+  fNPSSpect(nullptr)
+{
+  // Constructor  
+}
+  
+//________________________________________________________________________
+THcNPSCoinTime::~THcNPSCoinTime()
+{
+  // Destructor
+  RemoveVariables();
+}
+
+//________________________________________________________________________
+THcNPSCoinTime::Clear( Option_t* opt )
+{
+
+  fROC1_epCoinTime = kBig;
+  fROC_RAW_CoinTime = fNPS_RAW_CoinTime = fHMS_RAW_CoinTime = kBig;
+  elec_coinCorr = had_coinCorr_Proton = kBig;
+}
+
+//________________________________________________________________________
+THcNPSCoinTime::Reset( Option_t* opt )
+{
+  Clear(opt);
+}
+
+//________________________________________________________________________
+THaAnalysisObject::Estatus THcNPSCoinTime::Init( const TDatime& run_time )
+{
+
+  // Locate the spectrometer appratus and save pointer to it
+  cout << "*************************************************" << endl;
+  cout << "Initializing THcNPSCointTime Physics Modue" << endl;
+  cout << "Hadron Arm   -------> " << fhadArmName << endl;
+  cout << "Electron Arm -------> " << felecArmName << endl;
+  cout << "TrigDet  -------> " << fCoinDetName << endl;
+  cout << "**************************************************" << endl;
+
+  fStatus = kOK;
+
+  if (THaPhysicsModule::Init( run_time ) != kOK )
+    return fStatus;
+
+  // Get spectrometers
+  if (felecArmName == "H") {
+    // HMS
+    fHMSSpect = dynamic_cast<THaSpectrometer*>
+      ( FindModule( felecArmName.Data(), "THcHallCSpectrometer"));
+    // NPS
+    fNPSSpect = dynamic_cast<THcNPSApparatus*>
+      ( FindModule( fhadArmName.Data(), "THcNPSApparatus"));
+  }
+  else {
+    fHMSSpect = dynamic_cast<THaSpectrometer*>
+      ( FindModule( fhadArmName.Data(), "THcHallCSpectrometer"));
+    
+    fNPSpect = dynamic_cast<THcNPSApparatus*>
+      ( FindModule( felecArmName.Data(), "THcNPSApparatus"));
+  }
+
+  if( !fHMSSpect || !fNPSSpect )
+    fStatus = kInitError;
+  
+  fCoinDet = dynamic_cast<THcTrigDet*>
+    ( FindModule( fCoinDetName.Data(), "THcTrigDet"));
+  if( !fCoinDet ) {
+    cout << "THcCoinTime module  Cannnot find TrigDet = " << fCoinDetName.Data() << endl;
+    fStatus = kInitError;
+    return fStatus;
+  }
+  
+  // Get NPS calorimeter
+  fNPSCalo = dynamic_cast<THcNPSCalorimeter*>(fNPSSpect->GetDetector("cal"));
+  if( !fNPSCalo ) {
+    cout <<
+    fStatus = kInitError;
+  }
+
+  // NPS angle   
+  fNPSAngle = TMath::DegToRad()*fNPSSpect->GetNPSAngle();
+  
+  return fStatus;
+}
+
+//________________________________________________________________________
+Int_t THcNPSCoinTime::ReadDatabase( const TDatime& date )
+{
+  
+  DBRequest list[] = {
+    {"eHadCoinTime_Offset", &feHad_CT_Offset,    kDouble, 0, 1}, // coin time offset for ep coincidence
+    {"HMS_CentralPathLen",  &fHMScentralPathLen, kDouble, 0, 1},
+    {"NPS_CentralPathLen",  &fNPScentralPathLen, kDouble, 0, 1},
+    {0}
+  };
+
+  // Default values if not read from param file
+  feHad_CT_Offset = 0.0;
+  fHMScentralPathLen = 22.*100;
+  fNPScentralPathLen = 18.1*100; // FIXME: update value for NPS!
+
+  gHcParms->LoadParmValues((DBRequest*)&list, "");
+
+  return kOK;
+}
+
+//________________________________________________________________________
+Int_t THcNPSCoinTime::DefineVariables( EMode mode )
+{
+
+  if( mode == kDefine && fIsSetup ) return kOK;
+  fIsSetup = ( mode == kDefine );
+
+  RVarDef vars[] = {
+    {"epCoinTime_ROC1",    "ROC1 Corrected ep Coincidence Time", "fROC1_epCoinTime"},
+    {"epCoinTime_NPS",     "NPS Corrected ep Coincidence Time",  "fNPS_epCoinTime"},
+    {"epCoinTime_HMS",     "HMS Corrected ep Coincidence Time",  "fHMS_epCoinTime"},
+    
+    {"CoinTime_RAW_ROC1",  "ROC1 RAW Coincidence Time",          "fROC1_RAW_CoinTime"},
+    {"CoinTime_RAW_NPS",   "NPS RAW Coincidence Time",           "fNPS_RAW_CoinTime"},
+    {"CoinTime_RAW_HMS",   "HMS RAW Coincidence Time",           "fHMS_RAW_CoinTime"},
+
+    {"DeltaHMSPathLength", "DeltaHMSpathLength (cm)",            "fDeltaHMSpathLength"},
+
+    {"elec_coinCorr",          "",  "elec_coinCorr"},
+    {"had_coinCorr_proton",    "",  "had_coinCorr_Proton"},
+    {0}
+  };
+
+  return DefineVarsFromList( vars, mode );
+}
+
+//________________________________________________________________________
+Int_t THcNPSCoinTime::Process( const THaEvData& evdata )
+{
+
+  if( !IsOK() ) return -1;
+
+  // Get HMS tracks
+  THaTrackInfo* hms_trkifo = fHMSSpect->GetTrackInfo();
+  if( !hms_trkifo ) return 1;
+
+  // Get NPS clusters
+  if( fNPSCalo->GetNClusters() == 0 ) return 1;
+
+  theHMSTrack = fHMSSpect->GetGoldenTrack();
+  if( !theHMSTrack )
+    return 1;
+
+  // Loop over all clusters
+  // We don't have a "Golden cluster", use highest energy cluster for now
+  Double_t ClustMaxE = 0.;
+  Double_t NPS_FPtime = kBig;
+  TVector3 pvect;
+  TVector3 vertex = theHMSTrack->GetVertex();  // Use vertex from HMS
+  for(auto& cluster : fNPSCalo->GetClusters()) {
+    if( cluster.E() > ClusterMaxE ) {
+      ClusterMaxE = cluster.E();
+
+      // Get P vector in lab frame
+      cluster.RotateToLab(fNPSAngle, vertex, pvect);      
+
+      // Cluster time
+      NPS_FPtime = cluster.GetTime(); 
+    }// if found higher energy cluster
+  }
+
+  // HMS
+  Double_t hms_xptar = theHMSTrack->GetTTheta();
+  Double_t hms_dP = theHMSTrack->GEtDp();
+  Double_t hms_xfp = theHMSTrack->GEtX();
+  Double_t hms_xpfp = theHMSTrack->GetTheta();
+  Double_t hms_ypfp = theHMSTrack->GetPhi();
+  Double_t HMS_FPtime = theHMSTrack->GetFPTime();
+  
+  // Assume these are values when the variable is initialized
+  if (NPS_FPtime == -2000 || HMS_FPtime == -2000) return 1;
+  if (NPS_FPtime == -1000 || HMS_FPtime == -1000) return 1;
+
+  // We only use ROC1
+  pNPS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(0);  // pTRIG1_ROC1
+  pHMS_TdcTime_ROC1 = fCoinDet->Get_CT_Trigtime(1);  // pTRIG3_ROC1
+  
+  fDeltaHMSpathLength = -1.0*(12.462*hms_xpfp + 0.1138*hms_xpfp*hms_xfp - 0.0154*hms_xfp - 72.292*hms_xpfp*hms_xpfp - 0.0000544*hms_xfp*had_xfp - 116.52*hms_ypfp*hms_ypfp);
+  fDeltaHMSpathLength = (.12*hms_xptar*1000 +0.17*hms_dP/100.);
+  
+  // First assume NPS is the electron arm
+  Double_t ElecPathLength = fNPScentralPathLen;
+  Double_t HadPathLength  = fHMScentralPathLen + fDeltaHMSpathLength;
+  Double_t elec_P = pvect.Mag();
+  Double_t had_P = theHMSTrack->GetP();
+  Int_t sign= -1;
+  if(felecArmName == "H") {
+    ElecPathLength = fHMScentralPathLen + fDeltaHMSpathLength;
+    HadPathLength  = fNPScentralPathLen;    // NPS dP = 0
+    elec_P = theHMSTrack->GetP();                     // HMS golden track momentum
+    had_P = pvect.Mag();                             // NPS golden cluster momentum
+    sign = 1;
+  }
+  
+  // beta calculations beta = v/c = p/E
+  elecArm_BetaCalc = elec_P / sqrt(elec_P*elec_P + MASS_ELECTRON*MASS_ELECTRON);
+  hadArm_BetaCalc_proton = had_P / sqrt(had_P*had_P + MASS_PROTON*MASS_PROTON);
+
+  //Coincidence Corrections
+  elec_coinCorr = (ElecPathLength) / (LIGHTSPEED * elecArm_BetaCalc );
+  had_coinCorr_proton = (HadPathLength) / (LIGHTSPEED * hadArm_BetaCalc_proton );
+
+  // Comment out other hadron parts, keeping here in case someone needs them.
+  /*
+  hadArm_BetaCalc_Kaon = had_P / sqrt(had_P*had_P + kaonMass*kaonMass);
+  hadArm_BetaCalc_Pion = had_P / sqrt(had_P*had_P + pionMass*pionMass);	
+  hadArm_BetaCalc_Positron = had_P / sqrt(had_P*had_P + positronMass*positronMass);
+
+  had_coinCorr_Kaon =  (HadPathLength)/ (lightSpeed * hadArm_BetaCalc_Kaon );
+  had_coinCorr_Pion =  (HadPathLength)/ (lightSpeed * hadArm_BetaCalc_Pion );
+  had_coinCorr_Positron = (HadPathLength) / (lightSpeed SHMSadArm_BetaCalc_PSHMStron );
+  */  
+
+  //Raw, Uncorrected Coincidence Time
+  fROC1_RAW_CoinTime =  (pNPS_TdcTime_ROC1 + NPS_FPtime) - (pHMS_TdcTime_ROC1 + HMS_FPtime);
+
+  // Not sure if we want to keep those
+  fNPS_RAW_CoinTime = NPS_FPtime - HMS_FPtime; // essentially same as fHMS_RAW_CoinTime
+  fHMS_RAW_CoinTime = NPS_FPtime - HMS_FPtime;
+
+  // Corrected Coincidence Time for ROC1
+  fROC1_epCoinTime = fROC1_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; 
+  fNPS_epCoinTime = fNPS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; // essentially same as fHMS_epCoinTime
+  fHMS_epCoinTime = fHMS_RAW_CoinTime + sign*( elec_coinCorr-had_coinCorr_proton) - feHad_CT_Offset; 
+
+  return 0;
+}
+
+ClassImp(THcNPSCoinTime)

--- a/src/THcNPSCoinTime.h
+++ b/src/THcNPSCoinTime.h
@@ -64,6 +64,9 @@ class THcNPSCoinTime : public THaPhysicsModule {
 
   Double_t fROC1_RAW_CoinTime1;
   Double_t fROC1_RAW_CoinTime2;
+  Double_t fROC1_RAW_CoinTime1_NoTrack;
+  Double_t fROC1_RAW_CoinTime2_NoTrack;
+
   Double_t fNPS_RAW_CoinTime;
   Double_t fHMS_RAW_CoinTime;
 

--- a/src/THcNPSCoinTime.h
+++ b/src/THcNPSCoinTime.h
@@ -13,17 +13,16 @@
 //////////////////////////////////////////////
 
 #include "TString.h"
-
 #include "THaPhysicsModule.h"
-#include "THaTrack.h"
 #include "THcTrigDet.h"
 #include "THcHallCSpectrometer.h"
+#include "THaTrack.h"
 #include "THcNPSApparatus.h"
 #include "THcNPSCalorimeter.h"
 
-#define LIGHTSPEED 29.9792;          // cm/ns
-#define MASSS_ELECTRON 0.000510998;  // electron mass in GeV/c^2
-#define MASSS_PROTON 0.93827208;     // proton mass in GeV/c^2
+#define LIGHTSPEED 29.9792         // cm/ns
+#define MASS_ELECTRON 0.000510998  // electron mass in GeV/c^2
+#define MASS_PROTON 0.93827208     // proton mass in GeV/c^2
 
 class THcNPSCoinTime : public THaPhysicsModule {
  public:
@@ -58,25 +57,28 @@ class THcNPSCoinTime : public THaPhysicsModule {
   Double_t fNPSAngle;
   Double_t feHad_CT_Offset;
   Double_t fHMScentralPathLen;
-  Double_t fNPScentralPathLeh;
+  Double_t fNPScentralPathLen;
 
   // Calculated using HMS track
   Double_t fDeltaHMSpathLength;
 
-  Double_t fROC1_RAW_CoinTime;
+  Double_t fROC1_RAW_CoinTime1;
+  Double_t fROC1_RAW_CoinTime2;
   Double_t fNPS_RAW_CoinTime;
   Double_t fHMS_RAW_CoinTime;
 
-  Double_t fROC1_epCoinTime;
+  Double_t fROC1_epCoinTime1;
+  Double_t fROC1_epCoinTime2;
   Double_t fNPS_epCoinTime;
   Double_t fHMS_epCoinTime;
 
   // Trigger time pTrig1 T1 (NPS VTP||EDTM) and T3 (HMS 3/4)
   Double_t pNPS_TdcTime_ROC1;
   Double_t pHMS_TdcTime_ROC1;
+  Double_t pELRE_TdcTime_ROC1;
 
   Double_t elec_coinCorr;
-  Double_t had_coinCorr_Proton;
+  Double_t had_coinCorr_proton;
 
   ClassDef(THcNPSCoinTime,0)
 };

--- a/src/THcNPSCoinTime.h
+++ b/src/THcNPSCoinTime.h
@@ -1,0 +1,84 @@
+#ifndef ROOT_THcNPSCoinTime
+#define ROOT_THcNPSCoinTime
+
+//////////////////////////////////////////////
+//
+// THcNPSCoinTime
+//
+// Calculate coincidence times for a pair of
+// NPS + HMS spectrometer. 
+// timing offsets for different paddles are handled
+// in the detector class (e.g. THcNPSArray)
+//
+//////////////////////////////////////////////
+
+#include "TString.h"
+
+#include "THaPhysicsModule.h"
+#include "THaTrack.h"
+#include "THcTrigDet.h"
+#include "THcHallCSpectrometer.h"
+#include "THcNPSApparatus.h"
+#include "THcNPSCalorimeter.h"
+
+#define LIGHTSPEED 29.9792;          // cm/ns
+#define MASSS_ELECTRON 0.000510998;  // electron mass in GeV/c^2
+#define MASSS_PROTON 0.93827208;     // proton mass in GeV/c^2
+
+class THcNPSCoinTime : public THaPhysicsModule {
+ public:
+  THcNPSCoinTime( const char* name, const char* description,
+		  const char* elecArmName="", const char* hadArmName="",
+		  const char* coinname="");
+
+  virtual ~THcNPSCoinTime();
+    
+  virtual EStatus Init( const TDatime& run_time ) ;
+  virtual Int_t   Process( const THaEvData& );
+
+  void            Clear( Option_t* opt="" );
+  void            Reset( Option_t* opt = "" );
+
+ protected:
+
+  virtual Int_t ReadDatabase( const TDatime& date );
+  virtual Int_t DefineVariables( EMode mode = kDefine );
+
+  TString               fCoinDetName;
+  THcTrigDet           *fCoinDet;
+  TString               felecArmName;
+  TString               fhadArmName;
+  THcHallCSpectrometer *fHMSSpect;    // HMS
+  THcNPSApparatus      *fNPSSpect;    // NPS
+  THcNPSCalorimeter    *fNPSCalo;
+
+  THaTrack             *theHMSTrack;
+
+  // Read from Database
+  Double_t fNPSAngle;
+  Double_t feHad_CT_Offset;
+  Double_t fHMScentralPathLen;
+  Double_t fNPScentralPathLeh;
+
+  // Calculated using HMS track
+  Double_t fDeltaHMSpathLength;
+
+  Double_t fROC1_RAW_CoinTime;
+  Double_t fNPS_RAW_CoinTime;
+  Double_t fHMS_RAW_CoinTime;
+
+  Double_t fROC1_epCoinTime;
+  Double_t fNPS_epCoinTime;
+  Double_t fHMS_epCoinTime;
+
+  // Trigger time pTrig1 T1 (NPS VTP||EDTM) and T3 (HMS 3/4)
+  Double_t pNPS_TdcTime_ROC1;
+  Double_t pHMS_TdcTime_ROC1;
+
+  Double_t elec_coinCorr;
+  Double_t had_coinCorr_Proton;
+
+  ClassDef(THcNPSCoinTime,0)
+};
+
+#endif


### PR DESCRIPTION
Added THcNPSCoinTime module. It takes HMS spectrometer and NPS apparatus,
and uses HMS golden track and NPS cluster to calculate coincidence time.
We don't have a "golden cluster" selection for this, so currently we are using a cluster
with highest energy. Julie mentioned that using timing might be better for selecting 
a golden cluster -- something we can update as needed.

Mark Mathison updated THcNPSCalorimeter, THcNPSArray, THcNPSCluster, added 
cluster time and saved the cluster information (position, energy, time) into the tree output.

Some small fixes done to NPSSecondaryKine; vertex correction is done in 
THcNPSCluster:RotateToLab, and bug when choosing high energy cluster.