### PR TITLE
Add NPSTrackInfo to save the NPS track variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(src
   THcNPSCoinTime.cxx
   VTPModule.cxx
   VLDModule.cxx
+  THcNPSTrackInfo.cxx
   )
 
 # Headers

--- a/src/NPS_LinkDef.h
+++ b/src/NPS_LinkDef.h
@@ -14,5 +14,6 @@
 #pragma link C++ class THcNPSCoinTime+;
 #pragma link C++ class Decoder::VTPModule+;
 #pragma link C++ class Decoder::VLDModule+;
+#pragma link C++ class THcNPSTrackInfo+;
 
 #endif

--- a/src/THcNPSCalorimeter.cxx
+++ b/src/THcNPSCalorimeter.cxx
@@ -769,6 +769,7 @@ void THcNPSCalorimeter::ClusterHits(THcNPSShowerHitSet& HitSet,
   for (THcNPSShowerClusterListIt ppcl = (*ClusterList).begin(); 
        ppcl != (*ClusterList).end(); ++ppcl) {
     THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
+    cls.SetSize( (*ppcl)->size() ); // add cluster size
     fClusters.push_back(cls);
 
     fClusterX.push_back(cls.X());
@@ -1180,6 +1181,7 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
   for (THcNPSShowerClusterListIt ppcl = (*ClusterList).begin(); 
        ppcl != (*ClusterList).end(); ++ppcl) {
     THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
+    cls.SetSize( (*ppcl)->size() ); // add cluster size
     fClusters.push_back(cls);
 
     fClusterX.push_back(cls.X());

--- a/src/THcNPSCluster.cxx
+++ b/src/THcNPSCluster.cxx
@@ -46,21 +46,21 @@ void THcNPSCluster::RotateToLab(Double_t angle, TVector3& vertex, TVector3& pvec
 {
   // Set vertex vector
   fVertex = vertex;
-  fHasVertex = true;
 
   // Rotate along y-axis, correct for vertex
-  Double_t x_lab = fCenter.X()*cos(angle)  + fCenter.Z()*sin(angle) - vertex.X();
-  Double_t y_lab = fCenter.Y() - vertex.Y();
-  Double_t z_lab = -fCenter.X()*sin(angle) + fCenter.Z()*cos(angle) - vertex.Z();
+  Double_t x_lab = fCenter.X()*cos(angle)  + fCenter.Z()*sin(angle) - fVertex.X();
+  Double_t y_lab = fCenter.Y() - fVertex.Y();
+  Double_t z_lab = -fCenter.X()*sin(angle) + fCenter.Z()*cos(angle) - fVertex.Z();
 
   TVector3 rvect(x_lab, y_lab, z_lab);
   Double_t th = rvect.Theta();
   Double_t ph = rvect.Phi();
   
   fCenterLab = rvect;
-  pvect.SetXYZ(fE * cos(th) * sin(ph),
-	       fE * sin(th) * sin(ph),
-	       fE * cos(ph));
+  // TVector3: phi is polar angle and theta is azimuth
+  pvect.SetXYZ(fE * cos(ph) * sin(th),
+	       fE * sin(ph) * sin(th),
+	       fE * cos(th));
   
   fPvect = pvect;
 }

--- a/src/THcNPSCluster.h
+++ b/src/THcNPSCluster.h
@@ -31,12 +31,13 @@ class THcNPSCluster : public THaCluster {
   Double_t   GetTheta()                 { return fPvect.Theta(); } // in lab frame
   Double_t   GetPhi()                   { return fPvect.Phi(); }   // in lab frame
   Double_t   GetP()               const { return fP; }
-
+  Int_t      GetSize()            const { return fSize; } // cluster size
+  void       SetSize(Int_t nhits)            { fSize = nhits; } // cluster size
+  void       SetVertexFlag(bool vertex_flag) { fHasVertex = vertex_flag; }
   void       SetEnergy(Double_t energy)      { fE = energy; }
   void       SetTime(Double_t time)          { fT = time; }
   void       SetMomentum( Double_t p )       { fP = p; }
   void       SetPvect(const TVector3& pvect) { fPvect = pvect; }
-
   void       SetVertex(const TVector3& vertex) 
   { fVertex = vertex; fHasVertex = true; }
   void       SetVertex(Double_t vx, Double_t vy, Double_t vz) 
@@ -51,6 +52,7 @@ class THcNPSCluster : public THaCluster {
   TVector3 fVertex;     // vertex information from other spectrometer
   TVector3 fPvect;      // momentum vector
   TVector3 fCenterLab;  
+  Int_t    fSize;       // Cluster size
 
   ClassDef(THcNPSCluster,0)
 

--- a/src/THcNPSSecondaryKine.cxx
+++ b/src/THcNPSSecondaryKine.cxx
@@ -195,6 +195,7 @@ Int_t THcNPSSecondaryKine::Process( const THaEvData& )
 	ClusterMaxE = cluster.E();
 	// vertex correction and get P vector
 	cluster.RotateToLab(fNPSAngle, vertex, pvect);
+	if( vertex.Mag() < 1.e-38 ) cluster.SetVertexFlag(false);
       }
 
   // 4-momentum of X

--- a/src/THcNPSTrackInfo.cxx
+++ b/src/THcNPSTrackInfo.cxx
@@ -1,0 +1,141 @@
+// THcNPSTrackInfo
+
+#include "THcNPSTrackInfo.h"
+#include "THcNPSCluster.h"
+#include "THcNPSCalorimeter.h"
+#include "THcNPSApparatus.h"
+#include "THcReactionPoint.h"
+#include "THcParmList.h"
+#include "THcGlobals.h"
+#include "VarDef.h"
+#include "VarType.h"
+
+//_____________________________________________________________________
+THcNPSTrackInfo::THcNPSTrackInfo( const char* name, const char* description,
+				  const char* nps_apparatus,
+				  const char* vertex_module) :
+  THaPhysicsModule(name, description),
+  fSpectroName(nps_apparatus),
+  fVertexModuleName(vertex_module),
+  fSpectro(nullptr),
+  fNPSCalo(nullptr),
+  fVertexModule(nullptr)
+{
+  // Constructor
+  fHasVertex = false;
+  fVertex.SetXYZ(kBig, kBig, kBig);
+}
+
+//_____________________________________________________________________
+THcNPSTrackInfo::~THcNPSTrackInfo()
+{
+  // Destructor
+  DefineVariables( kDelete );
+}
+
+//_____________________________________________________________________
+void THcNPSTrackInfo::Clear( Option_t* opt )
+{
+  THaPhysicsModule::Clear(opt);
+  fNPSTrk.clear();
+  fVertex.SetXYZ(kBig, kBig, kBig);
+  fHasVertex = false;
+}
+
+//_____________________________________________________________________
+THaAnalysisObject::EStatus THcNPSTrackInfo::Init( const TDatime& run_time )
+{
+
+  fStatus = kOK;
+
+  // Find NPS Apparatus
+  fSpectro = dynamic_cast<THcNPSApparatus*>
+    ( FindModule( fSpectroName.Data(), "THcNPSApparatus") );    
+  if(!fSpectro) {
+    fStatus = kInitError;
+    return fStatus;
+  }
+
+  // Get NPS calorimeter detector
+  fNPSCalo = dynamic_cast<THcNPSCalorimeter*>(fSpectro->GetDetector("cal"));
+  fNPSAngle = fSpectro->GetNPSAngle();
+
+  // HMS Vertex Module (ReactionPoint)
+  fVertexModule = dynamic_cast<THcReactionPoint*>
+    ( FindModule( fVertexModuleName.Data(), "THcReactionPoint") );
+  if(!fVertexModule) {
+    fStatus = kInitError;
+    return fStatus;
+  }
+
+  if( (fStatus =THaPhysicsModule::Init( run_time )) != kOK ) {
+    return fStatus;
+  }
+
+  return fStatus;
+}
+
+//_____________________________________________________________________
+Int_t THcNPSTrackInfo::DefineVariables( EMode mode )
+{
+
+  if( mode == kDefine && fIsSetup ) return kOK;
+  fIsSetup = ( mode == kDefine );
+
+  // vx,vy,vz are same as H.react.x/y/z -- saved for xcheck
+  // trk.x and trk.y are same as the clusX, clusY from NPSCalorimeter -- saved for xcheck
+  RVarDef vars[] = {
+    {"vx",    "Vertex x from HMS track",              "fVertex.X()"},
+    {"vy",    "Vertex y from HMS track",              "fVertex.Y()"},
+    {"vz",    "Vertex z from HMS track",              "fVertex.Z()"},
+    {"px",    "Lab momentum px (GeV)",                "fNPSTrk.fPx" },
+    {"py",    "Lab momentum py (GeV)",                "fNPSTrk.fPy" },    
+    {"pz",    "Lab momentum pz (GeV)",                "fNPSTrk.fPz" },
+    {"p",     "Lab momentum (GeV)",                   "fNPSTrk.fP" },
+    {"mult",  "Cluster size",                         "fNPSTrk.fMult"},
+    {"x",     "x coordinate in detector front plane", "fNPSTrk.fX"},
+    {"y",     "y coordinate in detector front plane", "fNPSTrk.fY"},
+    { 0 }
+  };
+
+  return DefineVarsFromList( vars, mode );
+}
+
+//_____________________________________________________________________ 
+Int_t THcNPSTrackInfo::Process( const THaEvData& )
+{
+
+  if( !IsOK() ) return -1;
+
+  fNPSTrk.clear();  
+
+  if( fNPSCalo->GetNClusters() == 0 ) return 1;
+
+  if( fVertexModule->HasVertex() ) {
+    fVertex = fVertexModule->GetVertex();
+    fHasVertex = true;
+  }
+  
+  TVector3 pvect;
+  for( auto& cluster : fNPSCalo->GetClusters() ) {
+
+    if(fHasVertex) {
+      cluster.RotateToLab(fNPSAngle, fVertex, pvect);
+      cluster.SetVertexFlag(true);
+    }
+    else {
+      // if there is no vertex found from the HMS, it assumes (0,0,0) in THcNPSCluster,
+      // in case one wants to reconstruct the photon momentum vector for NPS single data
+      TVector3 Vtx_tmp(0,0,0);
+      cluster.RotateToLab(fNPSAngle, Vtx_tmp, pvect);
+      cluster.SetVertexFlag(false);
+    }
+
+    fNPSTrk.push_back( { pvect.Mag(), pvect.X(), pvect.Y(), pvect.Z(), cluster.X(), cluster.Y(), cluster.GetSize() } );
+
+  }
+  return 0;
+}
+
+//_____________________________________________________________________ 
+ClassImp(THcNPSTrackInfo)

--- a/src/THcNPSTrackInfo.h
+++ b/src/THcNPSTrackInfo.h
@@ -1,0 +1,66 @@
+#ifndef ROOT_THcNPSTrackInfo
+#define ROOT_THcNPSTrackInfo
+
+#include "THaPhysicsModule.h"
+#include "TVector3.h"
+
+class THcNPSApparatus;
+class THcNPSCalorimeter;
+class THcReactionPoint;
+class THcNPSCluster;
+
+class THcNPSTrackInfo : public THaPhysicsModule {
+
+ public:
+  THcNPSTrackInfo( const char* name, const char* description,
+	       const char* spectro = "",
+	       const char* vertex_module = "");
+  
+  virtual ~THcNPSTrackInfo();
+
+  virtual EStatus   Init( const TDatime& run_time );
+  virtual void      Clear( Option_t* opt="" );
+  virtual Int_t     Process( const THaEvData& );
+          void      SetSpectrometer( const char* name ) { fSpectroName = name; } // Treat it as a spectrometer assuming we make it so in the future
+          TVector3& GetVertex()                            { return fVertex; }
+          bool      HasVertex()                      const { return fHasVertex; }
+          void      SetVertex( Double_t vx, Double_t vy, Double_t vz )
+          { fVertex.SetXYZ(vx, vy, vz); fHasVertex = true; }
+          void      SetVertex( const TVector3& vertex )    { fVertex = vertex; fHasVertex = true; }
+
+ protected:
+  
+  virtual Int_t DefineVariables( EMode mode = kDefine );
+  //virtual Int_t ReadRunDatabase( const TDatime& date );
+  
+  TString fSpectroName; // not actually spectrometer, but in case we make the NPS as THcHallCSpectrometer in the future..
+  TString fVertexModuleName;
+  THcNPSApparatus*   fSpectro;
+  THcNPSCalorimeter* fNPSCalo;
+  THcReactionPoint*  fVertexModule;
+  
+  bool     fHasVertex;
+  TVector3 fVertex;
+  Double_t fNPSAngle;
+
+  class NPSTrack {
+  public:
+    Double_t fP;    // same as NPS cluster Energy
+    Double_t fPx;   // Momentum in lab
+    Double_t fPy;   // Momentum in lab
+    Double_t fPz;   // Momentum in lab 
+    Double_t fX;    // position on the detector plane 
+    Double_t fY;    // position on the detector plane
+    Int_t    fMult; // cluster size
+  };
+  std::vector<NPSTrack> fNPSTrk;
+
+ public:
+  std::vector<NPSTrack> GetTracks() { return fNPSTrk; }
+
+
+  ClassDef(THcNPSTrackInfo,0)
+
+};
+
+#endif /* ROOT_THcNPSTrackInfo */


### PR DESCRIPTION
THcNPSTrackInfo is a new physics module to save the NPS track quantities in the output tree.
This module requires NPS Apparatus and HMS ReactionPoint. It gets the cluster list from 
THcNPSCalorimeter and uses the HMS vertex to calculate the photon momentum for each cluster. 

I left the other NPS physics modules (THcNPSSecondaryKine, THcNPSCoinTime) as they are
for now, so that they can be still used whether we have THcNPSTrackInfo in the replay script or not.

Other minor changes include:
Added cluster size as track multiplicity.
Tae Hee found a bug in RotateToLab (polar and azimuthal angles were swapped).