### PR TITLE
Bug fix in block number id calculations

### DIFF
--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -677,9 +677,9 @@ Int_t THcNPSArray::CoarseProcess(TClonesArray& tracks)
   
   // Check that block id k computed correct for NPS
   UInt_t k=0;
-  for(UInt_t j=0; j < fNColumns; j++) {
-    for (UInt_t i=0; i<fNRows; i++) {
-
+  for (UInt_t i=0; i<fNRows; i++) {
+    for(UInt_t j=0; j < fNColumns; j++) {
+      
       if (fGoodAdcPulseInt.at(k) > 0) {    //hit
 
 	THcNPSShowerHit* hit =
@@ -688,7 +688,7 @@ Int_t THcNPSArray::CoarseProcess(TClonesArray& tracks)
 	HitSet.insert(hit);
       }
 
-      k++;			// k = j*fNRows + i
+      k++;			// k = i*fNColumns + j
     }
   }
 
@@ -740,7 +740,8 @@ Int_t THcNPSArray::CoarseProcess(TClonesArray& tracks)
     for (THcNPSShowerClusterIt pph=(**ppcl).begin(); pph!=(**ppcl).end();
 	   ++pph) {
       //C.Y. Feb 09, 2021: I believe a +1 is not necessary if block numbering starts at zero (simply, "block = column * fNRows + Row" will do)
-      block = ((**pph).hitColumn())*fNRows + (**pph).hitRow(); //+1; 
+      //      block = ((**pph).hitColumn())*fNRows + (**pph).hitRow(); //+1; 
+      block = ((**pph).hitRow())*fNColumns + (**pph).hitColumn(); //+1; 
       if (block >=0 && block < fNelem)  fBlock_ClusterID[block] = ncl;
       }
       ncl++;
@@ -813,16 +814,17 @@ Int_t THcNPSArray::CoarseProcessHits()
 
     Int_t nspar = 0;
     Int_t k=0;
-    for(UInt_t j=0; j < fNColumns; j++) {
     for (UInt_t i=0; i<fNRows; i++) {
-      if(fGoodAdcPulseIntRaw.at(k) > fThresh[k]) {
-	cout << "  counter =  " << k
-	     << "  E = " << fE[k]
-	     << endl;
-	nspar++;
+      for(UInt_t j=0; j < fNColumns; j++) {
+	
+	if(fGoodAdcPulseIntRaw.at(k) > fThresh[k]) {
+	  cout << "  counter =  " << k
+	       << "  E = " << fE[k]
+	       << endl;
+	  nspar++;
+	}
+	k++;
       }
-       k++;
-    }
     }
 
     if (nspar == 0) cout << "  No hits\n";
@@ -1365,7 +1367,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
     for(Int_t row=0;row<fNRows;row++) {
       cout << "|";
       for(Int_t column=0;column<fNColumns;column++) {
-	Int_t counter = column*fNRows + row;
+	Int_t counter = row*fNColumns + column;
 	if(fGoodAdcPulseIntRaw.at(counter) > threshold) {
 	  cout << "X";
 	} else {
@@ -1383,7 +1385,7 @@ Int_t THcNPSArray::AccumulateHits(TClonesArray* rawhits, Int_t nexthit, Int_t tr
 	hitpic[row][0] = '|';
       }
       for(Int_t column=0;column<fNColumns;column++) {
-	Int_t counter = column*fNRows+row;
+	Int_t counter = row*fNColumns + column;
 	if(fGoodAdcPulseIntRaw.at(counter) > threshold) {
 	  hitpic[row][piccolumn*(fNColumns+1)+column+1] = 'X';
 	} else {
@@ -1637,7 +1639,7 @@ std::pair<int, int> THcNPSArray::GetBlockij(Int_t id)
   for (UInt_t irow=0; irow<fNRows; irow++){
     for (UInt_t jcol=0; jcol<fNColumns; jcol++){
 
-      id_tmp = jcol * fNRows + irow;
+      id_tmp = irow * fNColumns + jcol;
 
       //check if block id matches input id
       if(id_tmp == id){
@@ -1665,7 +1667,8 @@ Int_t THcNPSArray::GetBlockID(UInt_t irow, UInt_t jcol)
   //  Int_t fNBlocks = fNRows * fNColumns; //total number of blocks (0 to  fNBlocks-1)
   
   //Calculate the block id based on the (i,j) indices
-  block_id = jcol * fNRows + irow;
+  //  block_id = jcol * fNRows + irow;
+  block_id = irow * fNColumns + jcol;
 
   //Check if input (irow, jcol) is out-of-bounds
   if( irow<0 || irow>=fNRows || jcol<0 || jcol>=fNColumns ){

--- a/src/THcNPSCalorimeter.cxx
+++ b/src/THcNPSCalorimeter.cxx
@@ -384,7 +384,7 @@ Int_t THcNPSCalorimeter::DefineVariables( EMode mode )
   // Register variables in global list
 
   RVarDef vars[] = {
-    { "nhits",        "Number of hits",                             "fNhits" },
+    { "nhits",        "(Total) Number of good hits",                "fNhits" },
     { "nclust",       "Number of layer clusters",                   "fNclust" },
     { "etot",         "Total energy",                               "fEtot" },
     { "clusX",        "Cluster x coordinate",                       "fClusterX" },
@@ -392,6 +392,7 @@ Int_t THcNPSCalorimeter::DefineVariables( EMode mode )
     { "clusZ",        "Cluster z coordinate",                       "fClusterZ" },
     { "clusT",        "Cluster time",                               "fClusterT" },
     { "clusE",        "Cluster energy",                             "fClusterE" },
+    { "clusSize",     "Cluster size",                               "fClusters.fSize" },
     { "vtpErrorFlag", "VTP error flag",           "fVTPErrorFlag"     },
     { "vtpTrigTime",  "VTP trigger time",         "fVTPTriggerTime"   },
     { "vtpTrigType0", "VTP trigger type0 bit",    "fVTPTriggerType0"  },
@@ -739,6 +740,8 @@ void THcNPSCalorimeter::ClusterHits(THcNPSShowerHitSet& HitSet,
   // of hits are saved in the ClusterList.
 
   //cout << "HitSet Size = " <<  HitSet.size() << endl;
+  fNhits = HitSet.size();
+
   while (HitSet.size() != 0) {
 
     THcNPSShowerCluster* cluster = new THcNPSShowerCluster;
@@ -784,7 +787,12 @@ void THcNPSCalorimeter::ClusterHits(THcNPSShowerHitSet& HitSet,
   for (THcNPSShowerClusterListIt ppcl = (*ClusterList).begin(); 
        ppcl != (*ClusterList).end(); ++ppcl) {
     THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
-    cls.SetSize( (*ppcl)->size() ); // add cluster size
+
+    // Add block IDs for the cluster
+    for(THcNPSShowerClusterIt pph=(*ppcl)->begin(); pph!=(*ppcl)->end(); ++pph) {
+      cls.AddBlock( (*pph)->hitID() );
+    }
+
     fClusters.push_back(cls);
 
     fClusterX.push_back(cls.X());
@@ -854,6 +862,7 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
     and can be used to understand how the algorithm contaminates other blocks based on a central virus block.
   */
 
+  fNhits = HitSet.size();
     
   //********************************************
   // PHASE 1 PREP: ARRAY/VECTORS INITIALIZATION
@@ -879,7 +888,6 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
     blk_hit_idx[ielem]=-1;
   }
   
-  
   //---------TESTING: ASSIGN PULSE INT USING HIT SET-------
   //Loop over ALL Hit blocks
   for (THcNPSShowerHitIt ihit=HitSet.begin(); ihit!=HitSet.end(); ++ihit) {
@@ -891,7 +899,7 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
     
     //Set hit block index
     blk_hit_idx[ (*ihit)->hitID() ] = fNbBlocks;
-    
+
     //increment hit block counter
     fNbBlocks++;
     
@@ -927,7 +935,7 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
     //If at a corner (only 3 neighboring blocks) and if at an edge (only 5 neighboring blocks)
     for(Int_t k=0;k<8;k++){
 
-      // cout<< "(k-index, Neighbor Block ID) = " << k << ", " <<  fArray->GetNeighbor(good_blk_id[j], k)  << endl; 
+      //cout<< "(k-index, Neighbor Block ID) = " << k << ", " <<  fArray->GetNeighbor(good_blk_id[j], k)  << endl; 
 
       //Check if kth neighbor block exists (is physically real) and  was actually hit (has good pulse integral)
       //if( fArray->GetNeighbor(good_blk_id[j], k)!=-1  && blk_pulseInt[ fArray->GetNeighbor(good_blk_id[j], k) ]>0 ){
@@ -1088,7 +1096,7 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
 	//Here is where the j-th hit block (that was not ill) is tagged' with the neighboring block highest pulseInt
 	pIpastmp[ good_blk_id[j] ]=max;  
 
-	// cout << "Neighbor w/ Highest Pulse Int | (Block Hit Index, PulseInt) =  " << virus_blk << ", " << max << endl;
+	//cout << "Neighbor w/ Highest Pulse Int | (Block Hit Index, PulseInt) =  " << good_blk_id[j] << " " << virus_blk << ", " << max << endl;
 	//Check if the found neighboring block (virus_blk) with the highest pulse Integral has been previously tagged as a virus 
 	if(virus[virus_blk]){
 
@@ -1196,7 +1204,12 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
   for (THcNPSShowerClusterListIt ppcl = (*ClusterList).begin(); 
        ppcl != (*ClusterList).end(); ++ppcl) {
     THcNPSCluster cls(clX(*ppcl), clY(*ppcl), clZ(*ppcl), clT(*ppcl), clE(*ppcl));
-    cls.SetSize( (*ppcl)->size() ); // add cluster size
+
+    // Add block IDs for the cluster
+    for(THcNPSShowerClusterIt pph=(*ppcl)->begin(); pph!=(*ppcl)->end(); ++pph) {
+      cls.AddBlock( (*pph)->hitID() );
+    }
+
     fClusters.push_back(cls);
 
     fClusterX.push_back(cls.X());

--- a/src/THcNPSCluster.cxx
+++ b/src/THcNPSCluster.cxx
@@ -10,6 +10,8 @@ THcNPSCluster::THcNPSCluster() :
 {
   // Constructor
 
+  fSize = 0;
+
   // Initialize momentum and vertex vectors
   fPvect.SetXYZ(0., 0., 0.);
   fVertex.SetXYZ(0., 0., 0.);
@@ -39,6 +41,9 @@ void THcNPSCluster::Clear( Option_t* )
   fCenterLab.SetXYZ( kBig, kBig, kBig);
   fHasVertex = false;
   fE = fT = fP = kBig;
+  fBlocks.clear();
+  fSize = 0;
+
 }
 
 //______________________________________________________

--- a/src/THcNPSCluster.h
+++ b/src/THcNPSCluster.h
@@ -21,6 +21,9 @@ class THcNPSCluster : public THaCluster {
   // Coordinate transformation from detector plane to lab
   virtual void RotateToLab(Double_t angle, TVector3& vertex, TVector3& pvect);
 
+  void  AddBlock(Int_t blockID) { fBlocks.push_back(blockID); fSize = fBlocks.size(); }
+  std::vector<Int_t> GetBlocks() { return fBlocks; }
+
   // Getter/Setter functions
   bool       HasVertex()          const { return fHasVertex; }
   Double_t   E()                  const { return fE; }
@@ -45,14 +48,16 @@ class THcNPSCluster : public THaCluster {
 
  protected:
 
-  Double_t fE;          // Cluster energy deposit
-  Double_t fT;          // Cluster time
-  Double_t fP;          // momentum
-  bool     fHasVertex;   
-  TVector3 fVertex;     // vertex information from other spectrometer
-  TVector3 fPvect;      // momentum vector
-  TVector3 fCenterLab;  
-  Int_t    fSize;       // Cluster size
+  Double_t fE;           // Cluster energy deposit
+  Double_t fT;           // Cluster time
+  Double_t fP;           // momentum
+  bool     fHasVertex;    
+  TVector3 fVertex;      // vertex information from other spectrometer
+  TVector3 fPvect;       // momentum vector
+  TVector3 fCenterLab;   
+  Int_t    fSize;        // Cluster size
+			 
+  std::vector<Int_t> fBlocks; // Blocks
 
   ClassDef(THcNPSCluster,0)
 


### PR DESCRIPTION
Mark Mathison had a detailed review on hcana and VTP cluster matching (https://redmine.jlab.org/issues/826), and found some issues with the hcana clusters:
1) cluster x,y positions don't make sense. 
2) hcana doesn't properly save a single cluster as one cluster (but split it into three clusters, for example). 

Both of the problems were because of a bug in block id calculations. This returns a wrong set of row, column numbers for the block, and therefore stores incorrect positions. Also, due to the wrong block id assignment, it doesn't get the neighboring blocks properly for the clustering.
After fixing it, we confirmed that both issues are resolved.