### PR TITLE
THcNPSCluster: convert angle from deg to rad in rotation

### DIFF
--- a/src/THcNPSCluster.cxx
+++ b/src/THcNPSCluster.cxx
@@ -52,6 +52,9 @@ void THcNPSCluster::RotateToLab(Double_t angle, TVector3& vertex, TVector3& pvec
   // Set vertex vector
   fVertex = vertex;
 
+  // Convert deg to rad
+  angle = angle * TMath::Pi() / 180.;
+
   // Rotate along y-axis, correct for vertex
   Double_t x_lab = fCenter.X()*cos(angle)  + fCenter.Z()*sin(angle) - fVertex.X();
   Double_t y_lab = fCenter.Y() - fVertex.Y();


### PR DESCRIPTION
While checking the photon momentum, found that the lab momentum px,py,pz don't make sense.
Especially, one would expect the lab momentum z to be always positive, but it was not.
Found that the NPS angle unit was not converted when computing the positions in lab frame in
THcNPSCluster::RoateToLab. After the fix, the variables look much more reasonable.
