### PR TITLE
THcNPSTrackInfo: Fix NPS angle unit from deg to rad

### DIFF
--- a/src/THcNPSTrackInfo.cxx
+++ b/src/THcNPSTrackInfo.cxx
@@ -58,7 +58,7 @@ THaAnalysisObject::EStatus THcNPSTrackInfo::Init( const TDatime& run_time )
 
   // Get NPS calorimeter detector
   fNPSCalo = dynamic_cast<THcNPSCalorimeter*>(fSpectro->GetDetector("cal"));
-  fNPSAngle = fSpectro->GetNPSAngle();
+  fNPSAngle = TMath::DegToRad() * fSpectro->GetNPSAngle();
 
   // HMS Vertex Module (ReactionPoint)
   fVertexModule = dynamic_cast<THcReactionPoint*>


### PR DESCRIPTION
NPS angle unit conversion missing in THcNPSTrackInfo.
Keeping THcNPSCluster::RotateToLab as it is so that it assumes
all angles are defined in rad.