### PR TITLE
Apply gain parameters to amp for block energies, use energy instead of pulse integral for clustering

### DIFF
--- a/src/THcNPSArray.cxx
+++ b/src/THcNPSArray.cxx
@@ -907,21 +907,20 @@ void THcNPSArray::FillADC_DynamicPedestal()
 	
 	
 	if(fGoodAdcPulseInt.at(npad)==0) {
-	  
 	  fTotNumGoodAdcHits++;
 	  fGoodAdcPulseInt.at(npad) = pulseInt;
-	  fE.at(npad) = fGoodAdcPulseInt.at(npad)*fGain[npad];
-	  fEarray += fE.at(npad);
-	  
 	  fGoodAdcPed.at(npad) = pulsePed;
 	  fGoodAdcPulseAmp.at(npad) = pulseAmp;
 	  fGoodAdcPulseTime.at(npad) = pulseTime;
 	  fGoodAdcTdcDiffTime.at(npad) = adctdcdiffTime;
 	  
+	  // Gain pararmeter is obtained for amp -> ene conversion
+	  fE.at(npad) = fGoodAdcPulseAmp.at(npad)*fGain[npad];
+	  fEarray += fE.at(npad);
+
 	  fNumGoodAdcHits.at(npad) = npad;// Looks wrong, but is correct. 
 	  // See https://github.com/JeffersonLab/hcana/issues/463
 	  // Not npad+1 here because we number first block as 0
-	  	         
 	}
 	
 	//}

--- a/src/THcNPSCalorimeter.cxx
+++ b/src/THcNPSCalorimeter.cxx
@@ -892,10 +892,11 @@ void THcNPSCalorimeter::ClusterNPS_Hits(THcNPSShowerHitSet& HitSet, THcNPSShower
   //Loop over ALL Hit blocks
   for (THcNPSShowerHitIt ihit=HitSet.begin(); ihit!=HitSet.end(); ++ihit) {
 
-    //fill  vectors
-    blk_pulseInt[ (*ihit)->hitID() ]    =  (*ihit)->hitPI();
+    // fill  vectors
+    // Use energy instead of integral for clustering 10/09/2023 S.P
+    blk_pulseInt[ (*ihit)->hitID() ]    =  (*ihit)->hitE();
     good_blk_id.push_back( (*ihit)->hitID() );
-    good_blk_pulseInt.push_back( (*ihit)->hitPI() );
+    good_blk_pulseInt.push_back( (*ihit)->hitE() );
     
     //Set hit block index
     blk_hit_idx[ (*ihit)->hitID() ] = fNbBlocks;


### PR DESCRIPTION
The gain coefficients convert the pulse amp to energy while NPSlib calcualte 
the energy by applying the coefficients to the pulse integrals. Changed the
energy calculation for each block to use PulseAmp * fGain.

Also, updated THcNPSCalorimeter::ClusterNPS_Hits to use the block energy
instead of pulse integral.