### PR TITLE
Vtp update adn THcNPSArray update

### DIFF
--- a/src/THcNPSCalorimeter.h
+++ b/src/THcNPSCalorimeter.h
@@ -113,9 +113,13 @@ protected:
   static const Int_t fnVTP = 5;
   Int_t fVTPErrorFlag;
   std::vector<UInt_t> fVTPTriggerTime;
+  std::vector<Int_t> fVTPTriggerCrate;
   std::vector<UInt_t> fVTPTriggerType0;
   std::vector<UInt_t> fVTPTriggerType1;
   std::vector<UInt_t> fVTPTriggerType2;
+  std::vector<UInt_t> fVTPTriggerType3;
+  std::vector<UInt_t> fVTPTriggerType4;
+  std::vector<UInt_t> fVTPTriggerType5;
 
   std::vector<UInt_t> fVTPClusterEnergy;
   std::vector<UInt_t> fVTPClusterTime;

--- a/src/VTPModule.cxx
+++ b/src/VTPModule.cxx
@@ -191,6 +191,9 @@ void VTPModule::DecodeTriggerTime( UInt_t pdat, uint32_t data_type_id )
     uint32_t ttype0   = 0;
     uint32_t ttype1   = 0;
     uint32_t ttype2   = 0;
+    uint32_t ttype3   = 0;
+    uint32_t ttype4   = 0;
+    uint32_t ttype5   = 0;
     
     if( data_type_id ) {  // trigger decision word 1
       
@@ -200,10 +203,17 @@ void VTPModule::DecodeTriggerTime( UInt_t pdat, uint32_t data_type_id )
       if( (tpattern >> 0 ) & 0x1 ) ttype0 = 1;
       if( (tpattern >> 1 ) & 0x1 ) ttype1 = 1;
       if( (tpattern >> 2 ) & 0x1 ) ttype2 = 1;
-      
+      if( (tpattern >> 3 ) & 0x1 ) ttype3 = 1;
+      if( (tpattern >> 4 ) & 0x1 ) ttype4 = 1;
+      if( (tpattern >> 5 ) & 0x1 ) ttype5 = 1;
+
+      //      cout << " tpattern = " << tpattern << endl;
       vtp_trigger_data.trigtype0.push_back( ttype0 );
       vtp_trigger_data.trigtype1.push_back( ttype1 );
       vtp_trigger_data.trigtype2.push_back( ttype2 );
+      vtp_trigger_data.trigtype3.push_back( ttype3 );
+      vtp_trigger_data.trigtype4.push_back( ttype4 );
+      vtp_trigger_data.trigtype5.push_back( ttype5 );
       vtp_trigger_data.trigtime.push_back( ttime );
     }
     
@@ -375,7 +385,6 @@ Int_t VTPModule::Decode( const UInt_t* pdat )
     *fDebugFile << "**********************************************************************"
                 << "\n" << endl;
 #endif
-  
   return block_trailer_found;
 }
 

--- a/src/VTPModule.h
+++ b/src/VTPModule.h
@@ -39,6 +39,9 @@ public:
    inline virtual std::vector<UInt_t> GetTriggerType0() { return vtp_trigger_data.trigtype0; }
    inline virtual std::vector<UInt_t> GetTriggerType1() { return vtp_trigger_data.trigtype1; }
    inline virtual std::vector<UInt_t> GetTriggerType2() { return vtp_trigger_data.trigtype2; }
+   inline virtual std::vector<UInt_t> GetTriggerType3() { return vtp_trigger_data.trigtype3; }
+   inline virtual std::vector<UInt_t> GetTriggerType4() { return vtp_trigger_data.trigtype4; }
+   inline virtual std::vector<UInt_t> GetTriggerType5() { return vtp_trigger_data.trigtype5; }
 
    inline virtual std::vector<UInt_t> GetClusterEnergy() { return vtp_cluster_data.energy; }
    inline virtual std::vector<UInt_t> GetClusterTime()   { return vtp_cluster_data.time; }
@@ -59,9 +62,9 @@ public:
    } __attribute__((aligned(128))) vtp_header_data;  
    
    struct vtp_trigger_data_struct {
-     std::vector<uint32_t> trigtime, trigtype0, trigtype1, trigtype2;   
+     std::vector<uint32_t> trigtime, trigtype0, trigtype1, trigtype2, trigtype3, trigtype4, trigtype5;   
      void clear() {
-       trigtime.clear(); trigtype0.clear(); trigtype1.clear(); trigtype2.clear(); 
+       trigtime.clear(); trigtype0.clear(); trigtype1.clear(); trigtype2.clear(); trigtype3.clear(); trigtype4.clear(); trigtype5.clear(); 
      }
    } __attribute__((aligned(128))) vtp_trigger_data;
    


### PR DESCRIPTION
**Add code to use Hodoscope starttime THcNPSArray**
Updated THcNPSArray::Init to initilize the hodoscope

Updated THcNPSArray::FillADC_DynamicPedestal
to uncomment
if( fglHod ) StartTime = fglHod->GetStartTime();

hodoscope start time is centered around 50ns.
hardcoded this 50ns offset.
fGoodAdcPulseTime.at(npad) = pulseTime-(StartTime-50);

Also set the
frAdcPulseTime and frAdcSampPulseTime to
pulseTime-(StartTime-50)
These are the tree variable NPS.cal.fly.adcPulseTime and
NPS.cal.fly.adcSampPulseTime


To get the best time resolution need to use detector map
which uses the the Hodoscope FADC 3of4 trigger as the
reference time for the NPS calo detector.
Hodoscope 3of4 trigger is in ROC1 SLot 18 channel 11.

When using the hodoscope reference time need to
have an overall offset of +337ns to get the NPS ADC pulse
time back to around 150ns for the coincidence peak.
Add the parameter nps_cal_arr_adc_tdc_offset_all = 337.
which is added to every blocks individual time offset.


**Update VTPModule to get all TriggerTypes**
the VTP has five trigger types

	  0 - production singles
         1 - cosmic scintillator
	  2 - cosmic column
	  3 - pair threshold (1 cluster in crate)
	  4 - pair threshold (2 cluster in same crate)
	  5 - VLD
Previously only decoding first three and putting them in data.
Modified VTPModule::DecodeTriggerTime to fill
vtp_trigger_data.trigtype3
vtp_trigger_data.trigtype4
vtp_trigger_data.trigtype5

Added to VTPModule.h
GetTriggerType3()
GetTriggerType4()
GetTriggerType5()

Modified THcNPSCalorimeter to
put the 3 additional trigger types in the tree
vtpTrigType3, vtpTrigType4, vtpTrigType5

Also add vtpTrigCrate which is the vtp crate number
that is associated with the trigger. Ther can be multiple
trigger times for a crate.